### PR TITLE
Specify maven location for api-android gradle.

### DIFF
--- a/api-android/build.gradle
+++ b/api-android/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {


### PR DESCRIPTION
Not providing maven url can lead to gradle build issues.