### PR TITLE
Remove Authentication Activity exit button.

### DIFF
--- a/app/src/main/java/org/sana/android/activity/AuthenticationActivity.java
+++ b/app/src/main/java/org/sana/android/activity/AuthenticationActivity.java
@@ -154,7 +154,6 @@ public class AuthenticationActivity extends BaseActivity {
     EditText mInputPassword;
 
     Button mBtnLogin;
-    Button mBtnExit;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -289,10 +288,6 @@ public class AuthenticationActivity extends BaseActivity {
         switch (v.getId()) {
             case R.id.btn_login:
                 logIn();
-                break;
-            case R.id.btn_exit:
-                setResult(RESULT_CANCELED);
-                finish();
                 break;
             case R.id.btn_configure:
                 Intent configure = new Intent(this, BasicSettings.class);

--- a/app/src/main/res/layout-land/activity_authentication.xml
+++ b/app/src/main/res/layout-land/activity_authentication.xml
@@ -44,14 +44,6 @@
             android:text="@string/authentication_login" />
 
         <Button
-            android:id="@+id/btn_exit"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/general_exit"
-            android:onClick="submit"
-            android:layout_margin="5dp" />
-
-        <Button
             android:id="@+id/btn_configure"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_authentication.xml
+++ b/app/src/main/res/layout/activity_authentication.xml
@@ -75,17 +75,6 @@
             android:padding="16dp" />
 
         <Button
-            android:id="@+id/btn_exit"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/general_exit"
-            android:onClick="submit"
-            android:layout_margin="5dp"
-            android:layout_gravity="center"
-            android:minWidth="128dp"
-            android:padding="16dp" />
-
-        <Button
             android:id="@+id/btn_configure"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,6 @@
     <string name="general_uploading">Uploading</string>
     <string name="general_incomplete">incomplete</string>
     <string name="general_complete">complete</string>
-    <string name="general_exit">Exit</string>
     <string name="general_network_active">Network active</string>
     <string name="general_network_inactive">Network inactive</string>
     <string name="general_unknown">Unknown</string>
@@ -100,7 +99,6 @@
     <string name="menu_save_exit">Save &amp; Exit</string>
     <string name="menu_discard_exit">Discard &amp; Exit</string>
     <string name="menu_jump_to_question">Jump To A Question</string>
-    <string name="menu_exit">Exit</string>
     <string name="menu_view_pages">View pages</string>
 
     <!-- Settings Activity Strings -->


### PR DESCRIPTION
It is rare for Android apps to have an explicit exit button. This PR removes the button on the Authentication Activity.

Exit button removed:
![no_exit_button](https://user-images.githubusercontent.com/10334328/44740725-31799480-aac9-11e8-9fc4-04c33726aab5.png)
