### PR TITLE
Set EditText hint colors to be grey_medium.

### DIFF
--- a/app/src/main/res/layout-land/activity_authentication.xml
+++ b/app/src/main/res/layout-land/activity_authentication.xml
@@ -25,6 +25,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/authentication_username"
+            android:textColorHint="@color/edit_text_text_color_hint"
             android:inputType="text"
             android:textAppearance="?android:attr/textAppearanceLargeInverse" />
 
@@ -33,6 +34,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/authentication_password"
+            android:textColorHint="@color/edit_text_text_color_hint"
             android:inputType="textPassword"
             android:textAppearance="?android:attr/textAppearanceLargeInverse" />
 

--- a/app/src/main/res/layout/dialog_authentication.xml
+++ b/app/src/main/res/layout/dialog_authentication.xml
@@ -20,7 +20,8 @@
         android:layout_marginRight="4dp"
         android:layout_marginTop="16dp"
         android:hint="@string/authentication_username"
-        android:textColor="@color/background_material_light" />
+        android:textColor="@color/background_material_light"
+        android:textColorHint="@color/edit_text_text_color_hint" />
 
     <EditText
         android:id="@+id/password"
@@ -32,6 +33,7 @@
         android:layout_marginTop="4dp"
         android:fontFamily="sans-serif"
         android:hint="@string/authentication_password"
+        android:textColorHint="@color/edit_text_text_color_hint"
         android:inputType="textPassword" />
 
     <View

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -9,6 +9,11 @@
     <color name="due_today">#FF9933</color>
     <color name="grey_medium">#808080</color>
     <color name="grey_dark">#404040</color>
+
+    <!-- Edit Text colors -->
+    <color name="edit_text_text_color">@android:color/black</color>
+    <color name="edit_text_text_color_hint">@color/grey_medium</color>
+
     <!-- Progress Dialog colors -->
     <color name="bg_progressdialog">#8C4406</color>
     <color name="fg_progressdialog">#FFFFFF</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -95,7 +95,8 @@
     </style>
 
     <style name="Widget.EditText.Light" parent="@android:style/Widget.EditText">
-        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColor">@color/edit_text_text_color</item>
+        <item name="android:textColorHint">@color/edit_text_text_color_hint</item>
         <item name="android:background">@drawable/oval</item>
         <item name="android:gravity">left|start|center_vertical</item>
         <item name="android:padding">10dp</item>


### PR DESCRIPTION
On some Android versions, the default text color for hints is white. This is a problem for EditText elements, which have a white background. This PR adjusts the hint text color for EditText elements to be grey_medium.

Authentication Activity before:
![white_hint](https://user-images.githubusercontent.com/10334328/44743987-f3cd3980-aad1-11e8-9184-44de8745902b.png)

Authentication Activity after:
![grey_hint](https://user-images.githubusercontent.com/10334328/44743997-f7f95700-aad1-11e8-9946-9c0d0253abb4.png)
